### PR TITLE
use --needed when installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ By default, the installation is not updated; hence package versions are those of
 
 #### install
 
-Installing additional packages after updating the system is supported through option `install`. The package or list of packages are installed through `pacman --noconfirm -S`.
+Installing additional packages after updating the system is supported through option `install`. The package or list of packages are installed through `pacman --noconfirm -S --needed`.
 
 ```yaml
   - uses: msys2/setup-msys2@v1

--- a/main.js
+++ b/main.js
@@ -96,7 +96,7 @@ async function run() {
 
     if (p_install != '' && p_install != 'false') {
       core.startGroup('Installing additional packages...');
-      await pacman(['-S'].concat(p_install.split(' ')), {});
+      await pacman(['-S', '--needed'].concat(p_install.split(' ')), {});
       core.endGroup();
     }
 


### PR DESCRIPTION
So we don't reinstall existing packages.

Fixes #27