### PR TITLE
Run the first login shell in an extra output group

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,8 +68,12 @@ async function run() {
       core.endGroup();
     }
 
+    async function run(args, opts) {
+      await exec.exec('cmd', ['/D', '/S', '/C', cmd].concat(args), opts);
+    }
+
     async function pacman(args, opts) {
-      await exec.exec('cmd', ['/D', '/S', '/C', cmd, 'pacman', '--noconfirm'].concat(args), opts);
+      await run(['pacman', '--noconfirm'].concat(args), opts);
     }
 
     function changeGroup(str) {
@@ -80,7 +84,7 @@ async function run() {
     if (p_update) {
       core.startGroup('Disable CheckSpace...');
       //# reduce time required to install packages by disabling pacman's disk space checking
-      await exec.exec('cmd', ['/D', '/S', '/C', cmd, 'sed', '-i', 's/^CheckSpace/#CheckSpace/g', '/etc/pacman.conf']);
+      await run(['sed', '-i', 's/^CheckSpace/#CheckSpace/g', '/etc/pacman.conf']);
       changeGroup('Updating packages...');
       await pacman(['-Syuu'], {ignoreReturnCode: true});
       changeGroup('Killing remaining tasks...');
@@ -90,7 +94,7 @@ async function run() {
       core.endGroup();
     } else {
       core.startGroup('Starting MSYS2 for the first time...');
-      await exec.exec('cmd', ['/D', '/S', '/C', cmd].concat(['uname', '-a']));
+      await run(['uname', '-a']);
       core.endGroup();
     }
 

--- a/main.js
+++ b/main.js
@@ -81,6 +81,10 @@ async function run() {
       core.startGroup(str);
     }
 
+    core.startGroup('Starting MSYS2 for the first time...');
+    await run(['uname', '-a']);
+    core.endGroup();
+
     if (p_update) {
       core.startGroup('Disable CheckSpace...');
       //# reduce time required to install packages by disabling pacman's disk space checking
@@ -91,10 +95,6 @@ async function run() {
       await exec.exec('taskkill', ['/F', '/FI', 'MODULES eq msys-2.0.dll']);
       changeGroup('Final system upgrade...');
       await pacman(['-Suu'], {});
-      core.endGroup();
-    } else {
-      core.startGroup('Starting MSYS2 for the first time...');
-      await run(['uname', '-a']);
       core.endGroup();
     }
 


### PR DESCRIPTION
This way it's easier to see how much time it takes and what
gets executed the first time.

Fixes #28