### PR TITLE
Pass the shell arguments directly to bash

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -199,7 +199,7 @@ jobs:
         rm -rf node_modules
     - name: run action
       uses: ./
-    - run: msys2 go env
+    - run: msys2 -c "go env"
       env:
         MSYS2_PATH_TYPE: inherit
 
@@ -219,7 +219,7 @@ jobs:
       uses: ./
       with:
         path-type: inherit
-    - run: msys2 go env
+    - run: msys2 -c "go env"
 
   install:
     needs: [path-type]
@@ -292,3 +292,41 @@ jobs:
         update: true
         install: base-devel git
     - run: git describe --dirty --tags
+
+  errorhandling:
+    needs: [defaultdirty]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build action
+      shell: bash
+      run: |
+        npm ci
+        npm run pkg
+        rm -rf node_modules
+    - name: run action
+      uses: ./
+    - shell: msys2 {0}
+      run: |
+        (! false | true) || exit 1; # make sure "-o pipefail" is active  by default
+        [[ "$-" =~ 'e' ]] || exit 1; # make sure "set -e" is active by default
+
+  workingdir:
+    needs: [errorhandling]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build action
+      shell: bash
+      run: |
+        npm ci
+        npm run pkg
+        rm -rf node_modules
+    - name: run action
+      uses: ./
+    - shell: msys2 {0}
+      run: |
+        # make sure we are in checkout directory
+        dir="$(pwd)"
+        cd "$GITHUB_WORKSPACE"
+        [[ "$dir" == "$(pwd)" ]]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If option `release` is `false`, the default installation is used. Otherwise (by 
   - uses: msys2/setup-msys2@v1
 ```
 
-Then, for multi-line scripts:
+Then, for scripts:
 
 ```yaml
   - shell: msys2 {0}
@@ -30,10 +30,16 @@ Then, for multi-line scripts:
       uname -a
 ```
 
-Or, for single line commands:
+It is also possible to execute specific commands from cmd/powershell scripts/snippets. In order to do so, `-c` is required:
 
 ```yaml
-  - run: msys2 -c 'uname -a'
+  - shell: powershell
+    run: msys2 -c 'uname -a'
+```
+
+```yaml
+  - shell: cmd
+    run: msys2 -c 'uname -a'
 ```
 
 ### Default shell

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then, for multi-line scripts:
 Or, for single line commands:
 
 ```yaml
-  - run: msys2 uname -a
+  - run: msys2 -c 'uname -a'
 ```
 
 ### Default shell
@@ -90,7 +90,7 @@ Furthermore, the environment variable can be overridden. This is useful when mul
       pacman --noconfirm -U mingw-w64-*-any.pkg.tar.xz
   - run: |
       set MSYSTEM=MINGW64
-      msys2 <command to test the package>
+      msys2 -c '<command to test the package>'
 ```
 
 #### path-type


### PR DESCRIPTION
This allows us to run the "run" script using "set -eo pipefail" by default.

The previous wrapper executed the arguments as a bash command string, which
allowed the user to run any command, but didn't give us a chance to special case
if the argument was a script passed from the GHA "run" command.

This is a breaking change.

Porting guide:

* Instead of `msys2 mybinary` you now have to run `msys2 -c 'mybinary'`
* To revert the bash error settings you can use `set +e` and `set +o pipefail`
  in your run script

See #43