### PR TITLE
Change action name to be unique

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Setup MSYS2 environment'
+name: 'Setup MSYS2'
 description: 'Setup an MSYS2 environment'
 inputs:
   msystem:


### PR DESCRIPTION
Despite the other action being gone now github complains that the name is not unique. This tries to fix it.

(I'm open to naming ideas, I just looked the Python one which is called "Setup Python")

![Screenshot from 2020-07-17 15-25-02](https://user-images.githubusercontent.com/991986/87790986-ca426600-c841-11ea-83e3-2c7ff048f262.png)
