### PR TITLE
Rework pacman pkg cache and enable by default

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -6,26 +6,7 @@ on:
     - cron: '0 0 * * 3,6'
 jobs:
 
-  save:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: build action
-      shell: bash
-      run: |
-        npm ci
-        npm run pkg
-        rm -rf node_modules
-    - name: run action
-      uses: ./
-      with:
-        cache: save
-    - shell: msys2 {0}
-      run: |
-        uname -a
-
   cache:
-    needs: [save]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -39,7 +20,7 @@ jobs:
       uses: ./
       with:
         update: true
-        cache: true
+        install: base-devel git
     - shell: msys2 {0}
       run: |
         uname -a
@@ -71,7 +52,7 @@ jobs:
         msys2 ./test.sh MINGW32
 
   cmd:
-    needs: [powershell]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -100,7 +81,7 @@ jobs:
         msys2 ./test.sh MINGW32
 
   env:
-    needs: [cmd]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -126,7 +107,7 @@ jobs:
         MSYSTEM: MINGW32
 
   shell:
-    needs: [env]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -143,7 +124,7 @@ jobs:
         uname -a
 
   msystem:
-    needs: [shell]
+    needs: [cache]
     strategy:
       matrix:
         task: [ MSYS, MINGW64, MINGW32 ]
@@ -163,7 +144,7 @@ jobs:
     - run: msys2 ./test.sh ${{ matrix.task }}
 
   update:
-    needs: [msystem]
+    needs: [cache]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -186,7 +167,7 @@ jobs:
     - run: msys2 ./test.sh ${{ matrix.msystem }}
 
   MSYS2_PATH_TYPE:
-    needs: [update]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/setup-go@v1
@@ -204,7 +185,7 @@ jobs:
         MSYS2_PATH_TYPE: inherit
 
   path-type:
-    needs: [update]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/setup-go@v1
@@ -222,7 +203,7 @@ jobs:
     - run: msys2 -c "go env"
 
   install:
-    needs: [path-type]
+    needs: [cache]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -246,7 +227,7 @@ jobs:
     - run: msys2 ./test.sh MINGW64
 
   defaultclean:
-    needs: [install]
+    needs: [cache]
     runs-on: windows-latest
     defaults:
       run:
@@ -271,7 +252,7 @@ jobs:
     - run: git describe --dirty --tags
 
   defaultdirty:
-    needs: [install]
+    needs: [cache]
     runs-on: windows-latest
     defaults:
       run:
@@ -294,7 +275,7 @@ jobs:
     - run: git describe --dirty --tags
 
   errorhandling:
-    needs: [defaultdirty]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
@@ -312,7 +293,7 @@ jobs:
         [[ "$-" =~ 'e' ]] || exit 1; # make sure "set -e" is active by default
 
   workingdir:
-    needs: [errorhandling]
+    needs: [cache]
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -146,24 +146,6 @@ Installing additional packages after updating the system is supported through op
       install: 'git base-devel'
 ```
 
-#### cache
-
-If set to `true`, directory `/var/cache/pacman/pkg` is restored/cached in order to speed up future updates:
-
-```yaml
-  - uses: msys2/setup-msys2@v1
-    with:
-      cache: true
-```
-
-If set to `save`, the same directory is cached, but it is not restored. This can be used to force a save of a clean state.
-
-```yaml
-  - uses: msys2/setup-msys2@v1
-    with:
-      cache: save
-```
-
 ## Development
 
 The steps to publish a new release are the following:

--- a/action.yml
+++ b/action.yml
@@ -24,10 +24,6 @@ inputs:
     description: 'Install packages after installation through pacman'
     required: false
     default: false
-  cache:
-    description: 'Cache /var/cache/pacman/pkg to speed up future updates'
-    required: false
-    default: false
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
Three main improvements:

* Create a separate cache for each input configuration: Assuming a build matrix
  which builds for different arches and has different dependencies we create
  a cache for each of them, while loading any of them.
* Prune caches before saving them: Every time a package has a new version we
  create a new cache which only includes the new packages. This makes sure that
  the cache/restore size stays as small as possible over time.
* Avoid cache race conditions: If a run doesn't change the cache we wont save it
  and if saving fails because another job created it in the mean time,
  we catch the error and ignore it.

Overall this cache doesn't save much time, since installation and initial setup
take the most time, but this should save a lot of traffic for our main
repo server.

And also this removes the cache option which was confusing some users because it
only caches packages and not everything.