### PR TITLE
Cache the whole installation when possible

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -319,3 +319,24 @@ jobs:
         dir="$(pwd)"
         cd "$GITHUB_WORKSPACE"
         [[ "$dir" == "$(pwd)" ]]
+
+  norelease:
+    needs: [cache]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: build action
+      shell: bash
+      run: |
+        npm ci
+        npm run pkg
+        rm -rf node_modules
+    - name: run action
+      uses: ./
+      with:
+        release: false
+        update: false
+        install: ccache
+    - shell: msys2 {0}
+      run: |
+        uname -a


### PR DESCRIPTION
In case release=true we try to cache the whole installation.

As cache restore key we use the whole input + the installer checksum, so
we only get a similar setup back.

For saving we hash the content of /var/lib/pacman/local which contains all the info
about which packages are installed.

Fixes #50