### PR TITLE
Handle pacman upgrade creating .pacnew files

### DIFF
--- a/main.js
+++ b/main.js
@@ -247,6 +247,9 @@ async function run() {
       await runMsys(['sed', '-i', 's/^CheckSpace/#CheckSpace/g', '/etc/pacman.conf']);
       changeGroup('Updating packages...');
       await pacman(['-Syuu', '--overwrite', '*'], {ignoreReturnCode: true});
+      // We have changed /etc/pacman.conf above which means on a pacman upgrade
+      // pacman.conf will be installed as pacman.conf.pacnew
+      await runMsys(['mv', '-f', '/etc/pacman.conf.pacnew', '/etc/pacman.conf'], {ignoreReturnCode: true, silent: true});
       changeGroup('Killing remaining tasks...');
       await exec.exec('taskkill', ['/F', '/FI', 'MODULES eq msys-2.0.dll']);
       changeGroup('Final system upgrade...');


### PR DESCRIPTION
In case a pacman upgrade changes a file that is marked for backup
it leaves it alone and installs it as <name>.pacnew instead and warns
the user.

In our case we change pacman.conf to skip CheckSpace. If pacman would
then update itself it would save any new pacman.conf as pacman.conf.pacnew.
Fix this by replacing the file manually.