### PR TITLE
Output msysRootDir from action.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -69,6 +69,7 @@ jobs:
       with:
         name: action
     - name: run action
+      id: msys2
       uses: ./
     - name: test MSYS
       shell: cmd
@@ -85,6 +86,12 @@ jobs:
       run: |
         set MSYSTEM=MINGW32
         msys2 ./test.sh MINGW32
+    - name: test output
+      shell: cmd
+      run: |
+        set MSYSTEM=MSYS
+        echo ${{ steps.msys2.outputs.msysRootDir }}
+        call ${{ steps.msys2.outputs.msysRootDir }}\autorebase.bat
 
   env:
     needs: [cache]

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: 'Install packages after installation through pacman'
     required: false
     default: false
+outputs:
+  msysRootDir:
+    description: 'Path to the MSYS root'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/main.js
+++ b/main.js
@@ -224,6 +224,7 @@ async function run() {
       }
     }
 
+    core.setOutput("msysRootDir", msysRootDir);
     writeWrapper(msysRootDir, input.pathtype, dest, 'msys2.cmd');
     core.addPath(dest);
 


### PR DESCRIPTION
It's reasonable that another step might want to know this.

Calling autorebase.bat seemed a good way to test this, even though it shouldn't be needed on x86_64