### PR TITLE
readme: add section 'context'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,23 @@
 
 # Setup MSYS2
 
-[MSYS2](https://www.msys2.org/) is available by default in [windows-latest](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md#msys2) virtual environment for GitHub Actions. However, the default installation is updated every ~10 days, and it includes some pre-installed packages. As a result, startup time can be up to 10 min. Moreover, MSYS2/MINGW are neither added to the PATH nor available as a custom `shell` option.
+**setup-msys2** is a JavaScript GitHub Action (GHA) to setup an [MSYS2](https://www.msys2.org/) environment (i.e. MSYS, MINGW32 and/or MINGW64 shells) using the GHA [toolkit](https://github.com/actions/toolkit) for automatic caching.
 
-**setup-msys2** is a JavaScript GitHub Action (GHA) to optionally setup an up-to-date and stable [MSYS2](https://www.msys2.org/) environment in a temporal location, using the GHA [toolkit](https://github.com/actions/toolkit). Moreover, it provides a custom entrypoint.
+## Context
 
-If option `release` is `false`, the default installation is used. Otherwise (by default), the latest tarball available at [repo.msys2.org/distrib/x86_64](http://repo.msys2.org/distrib/x86_64/) is downloaded and extracted.
+[MSYS2](https://www.msys2.org/) is available by default in [windows-latest](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md#msys2) [virtual environment](https://github.com/actions/virtual-environments) for GitHub Actions, located at `C:\msys64`. Moreover, there is work in progress for making `bash` default to MSYS2 (see [actions/virtual-environments#1525](https://github.com/actions/virtual-environments/issues/1525)). However, the default installation has some caveats at the moment (see [actions/virtual-environments#1572](https://github.com/actions/virtual-environments/issues/1572)):
+
+- It is updated every ~10 days.
+- It includes a non-negligible set of pre-installed packages. As a result, update time can be up to 10 min.
+- Caching of installation packages is not supported.
+- MSYS2/MINGW are neither added to the PATH nor available as a custom `shell` option.
+
+**setup-msys2** works around those constraints:
+
+- Using option `release: false`, the default installation is used, but automatic caching is supported and a custom entrypoint is provided.
+- By default (`release: true`), **setup-msys2** downloads and extracts the latest tarball available at [repo.msys2.org/distrib/x86_64](http://repo.msys2.org/distrib/x86_64/), a clean and up-to-date environment is set up in a temporary location, and a custom entrypoint (`msys2`) is provided. Hence, the overhead of updating pre-installed but unnecessary packages is avoided.
+
+Therefore, usage of this Action is recommended to all MSYS2 users of GitHub Actions, since caching and the custom entrypoint are provided regardless of option `release`.
 
 ## Usage
 


### PR DESCRIPTION
Close #83

As discussed in #83, it is currently not clear enough in the README which are the target users of this Action. I had the hope for the context to stabilise after actions/virtual-environments#1648 was merged. However, it was rolled back, so it will take longer until the changes to the virtual environments provided by GitHub are applied: actions/virtual-environments#1525.

This PR adds a 'Context' section to the README, trying to explain the current status meanwhile. Note that I'm not a native speaker, so I'd be glad to receive style suggestions.

/cc @tobiasherzke @lazka