### PR TITLE
Refresh the DBs before the final upgrade as well

### DIFF
--- a/main.js
+++ b/main.js
@@ -258,7 +258,7 @@ async function run() {
       changeGroup('Killing remaining tasks...');
       await exec.exec('taskkill', ['/F', '/FI', 'MODULES eq msys-2.0.dll']);
       changeGroup('Final system upgrade...');
-      await pacman(['-Suu', '--overwrite', '*'], {});
+      await pacman(['-Syuu', '--overwrite', '*'], {});
       core.endGroup();
     }
 


### PR DESCRIPTION
In case we add a new repo in pacman we get a new pacman.conf which might
contain new repos which haven't been synced yet. This makes the final
upgrade fail with "database file [...] doesn't exist".

To prevent this also sync at the last step.

Fixes #119