### PR TITLE
cache installer in the toolcache

### DIFF
--- a/main.js
+++ b/main.js
@@ -175,7 +175,7 @@ async function writeWrapper(msysRootDir, pathtype, destDir, name) {
 
 async function runMsys(args, opts) {
   assert.ok(cmd);
-  const quotedArgs = args.map((arg) => {return `'${arg.replace(/'/g, `'\\''`)}'`});
+  const quotedArgs = args.map((arg) => {return `'${arg.replace(/'/g, `'\\''`)}'`}); // fix confused vim syntax highlighting with: `
   await exec.exec('cmd', ['/D', '/S', '/C', cmd].concat(['-c', quotedArgs.join(' ')]), opts);
 }
 


### PR DESCRIPTION
Some concern about caching the entire install, but this should at least save self-hosted runners having to download the installer every run.

Enhancement for #145 