### PR TITLE
location: Make directory before using it.

### DIFF
--- a/main.js
+++ b/main.js
@@ -233,6 +233,7 @@ async function run() {
       // Use upstream package instead of the default installation in the virtual environment.
       let dest = (input.location) ? input.location : tmp_dir;
       msysRootDir = path.join(dest, 'msys64');
+      await io.mkdirP(msysRootDir);
 
       if (INSTALL_CACHE_ENABLED) {
         instCache = new InstallCache(msysRootDir, input);


### PR DESCRIPTION
The previous test was wotking because D:\ exist, Installing in another directory failed with `Error: The cwd: D:\M does not exist!`