### PR TITLE
Switch to nodejs v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,5 +37,5 @@ inputs:
     required: false
     default: 'fatal'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
GHA supports v12 and v16, see https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing

v12 is EOL soon, so update.