### PR TITLE
Port to ES modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,14 @@
 {
     "env": {
-        "commonjs": true,
         "es2020": true,
         "node": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 11
+        "ecmaVersion": 11,
+        "sourceType": "module"
     },
     "rules": {
     },
-    "ignorePatterns": [
-        "index.js"
-    ]
+    "ignorePatterns": ["dist/*.js"]
 }

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -33,9 +33,9 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: action
-        path: index.js
+        path: dist
     - name: 🚧 run action
-      uses: ./
+      uses: ./dist
       with:
         update: true
         install: base-devel git

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ typings/
 
 # next.js build output
 .next
+
+dist/

--- a/main.js
+++ b/main.js
@@ -1,13 +1,20 @@
-const cache = require('@actions/cache');
-const core = require('@actions/core');
-const io = require('@actions/io');
-const exec = require('@actions/exec');
-const tc = require('@actions/tool-cache');
-const path = require('path');
-const fs = require('fs');
-const crypto = require('crypto');
-const assert = require('assert').strict;
-const { hashElement } = require('folder-hash');
+import cache from '@actions/cache';
+import core from '@actions/core';
+import io from '@actions/io';
+import exec from '@actions/exec';
+import tc from '@actions/tool-cache';
+import path from 'node:path';
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import assert from 'node:assert/strict';
+import process from 'node:process';
+import { hashElement } from 'folder-hash';
+
+// XXX: hack to make ncc copy those files to dist
+// eslint-disable-next-line
+function dummy() {
+    return [__dirname + '/action.yml', __dirname + '/README.md'];
+}
 
 const inst_version = '2022-10-28';
 const inst_url = `https://github.com/msys2/msys2-installer/releases/download/${inst_version}/msys2-base-x86_64-${inst_version.replace(/-/g, '')}.sfx.exe`;

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
     "type": "git",
     "url": "git+https://github.com/msys2/setup-msys2.git"
   },
+  "type": "module",
   "scripts": {
-    "pkg": "ncc build main.js -m -o ./",
+    "pkg": "ncc build main.js --minify --out dist",
     "lint": "eslint ."
   },
   "keywords": [

--- a/release.sh
+++ b/release.sh
@@ -14,8 +14,6 @@ GIT_EMAIL="$(git config user.email)"
 GIT_SHA="$(git rev-parse HEAD)"
 GIT_ORIGIN="$(git config --get remote.origin.url)"
 
-mkdir dist
-cp README.md action.yml index.js dist
 cd dist
 git init
 git checkout --orphan "$1"


### PR DESCRIPTION
ncc will create a package.json which replaces the root package.json, so move the build output to "dist".

There should be no functional difference.