### PR TITLE
added 'uses: msys2/setup-msys2@v2' to cmake.yml

### DIFF
--- a/examples/cmake.yml
+++ b/examples/cmake.yml
@@ -31,6 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: '${{ matrix.icon }} Setup MSYS2'
+      uses: msys2/setup-msys2@v2
       with:
         msystem: ${{matrix.sys}}
         update: true


### PR DESCRIPTION
fix: missing  'uses: msys2/setup-msys2@v2'  added to example/cmake.yml