### PR TITLE
Call process.exit() at the end to avoid node waiting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
     },
     "extends": ["eslint:recommended", "plugin:jsdoc/recommended"],
     "parserOptions": {
-        "ecmaVersion": 11,
+        "ecmaVersion": 13,
         "sourceType": "module"
     },
     "rules": {

--- a/main.js
+++ b/main.js
@@ -455,4 +455,8 @@ async function run() {
   }
 }
 
-await run()
+
+await run();
+
+// https://github.com/actions/toolkit/issues/1578#issuecomment-1879770064
+process.exit();


### PR DESCRIPTION
Starting with the update to node20, in case we would call the GH cache upload functions the process would not exit right away, but stay around for 1-2 minutes doing nothing.

See https://github.com/actions/toolkit/issues/1578 for the upstream issue.

Work around by forcing node to exit.

Fixes #346