### PR TITLE
Add an output parameter for the install location

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -404,6 +404,7 @@ jobs:
         location:
         - D:\
         - D:\some\arbitrary
+        - RUNNER_TEMP
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -413,6 +414,7 @@ jobs:
         name: action
     - name: 🚧 run action
       uses: ./
+      id: msys2
       with:
         location: ${{ matrix.location }}
         update: false
@@ -421,12 +423,19 @@ jobs:
         cygpath -m /
     - shell: pwsh
       run: |
-        $Env:MSYS2_ROOT = msys2 -c 'cygpath -m /'
+        echo '${{ steps.msys2.outputs.msys2-location }}'
+    - shell: pwsh
+      run: |
+        $Env:MSYS2_ROOT = msys2 -c 'cygpath -a -w /'
         $Env:MSYS2_ROOT
+        if ($env:MSYS2_ROOT -ne '${{ steps.msys2.outputs.msys2-location }}') {
+            Write-Error "Error: MSYS2_ROOT is '$env:MSYS2_ROOT', expected '${{ steps.msys2.outputs.msys2-location }}'"
+            exit 1
+        }
     - shell: python
       run: |
         from subprocess import check_output
-        MSYS2_ROOT = check_output(['msys2', '-c', 'cygpath -m /'], shell=True).decode('utf-8')
+        MSYS2_ROOT = check_output(['msys2', '-c', 'cygpath -a -w /'], shell=True).decode('utf-8')
         print(MSYS2_ROOT)
 
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,18 @@ If set to `warn`, simply log a message and skip the rest:
       platform-check-severity: warn
 ```
 
+### Outputs
+
+#### msys2-location
+
+The absolute path of the MSYS2 installation location. Example: `D:\a\_temp\msys64` or `C:\msys64`.
+
+```yaml
+  - uses: msys2/setup-msys2@v2
+    id: msys2
+  - run: echo '${{ steps.msys2.outputs.msys2-location }}'
+```
+
 ### Advanced Options
 
 These options are rarely needed and shouldn't be used unless there is a good reason.

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
     description: 'If caching should be used'
     required: false
     default: true
+outputs:
+  msys2-location:
+    description: 'The absolute path of the MSYS2 installation location'
 runs:
   using: 'node20'
   main: 'index.js'

--- a/main.js
+++ b/main.js
@@ -373,6 +373,8 @@ async function run() {
     writeWrapper(msysRootDir, input.msystem, input.pathtype, pathDir, 'msys2.cmd');
     core.addPath(pathDir);
 
+    core.setOutput('msys2-location', msysRootDir);
+
     // XXX: ideally this should be removed, we don't want to pollute the user's environment
     core.exportVariable('MSYSTEM', input.msystem);
 


### PR DESCRIPTION
This adds the "msys2-location" output parameter which contains the absolute Windows path of the MSYS2 installation that was used by the action.

While cygpath can be used as well, some users might just want to use the path to pass it to some other tool and don't want to run any msys2 things themselves.

Similar to #228