### PR TITLE
CI: test on windows-11-arm

### DIFF
--- a/.github/workflows/PKGBUILD.yml
+++ b/.github/workflows/PKGBUILD.yml
@@ -27,7 +27,7 @@ jobs:
 
 
   win-makepkg:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,7 +83,7 @@ jobs:
 
   win-test:
     needs: win-makepkg
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -89,6 +89,26 @@ jobs:
         msys2 ./test.sh CLANG64
 
 
+  powershell-arm64:
+    needs: [cache]
+    runs-on: windows-11-arm
+    steps:
+    - name: 🧰 Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: 📥 Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: action
+    - name: 🚧 run action
+      uses: ./
+    - name: 🟩 test CLANGARM64
+      run: |
+        $env:MSYSTEM = 'CLANGARM64'
+        msys2 ./test.sh CLANGARM64
+
+
   cmd:
     needs: [cache]
     runs-on: windows-latest
@@ -129,6 +149,25 @@ jobs:
         set MSYSTEM=CLANG64
         msys2 ./test.sh CLANG64
 
+  cmd-arm64:
+    needs: [cache]
+    runs-on: windows-11-arm
+    steps:
+    - name: 🧰 Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: 📥 Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: action
+    - name: 🚧 run action
+      uses: ./
+    - name: 🟩 test CLANGARM64
+      shell: cmd
+      run: |
+        set MSYSTEM=CLANGARM64
+        msys2 ./test.sh CLANGARM64
 
   env:
     needs: [cache]
@@ -165,10 +204,33 @@ jobs:
       env:
         MSYSTEM: CLANG64
 
+  env-arm64:
+    needs: [cache]
+    runs-on: windows-11-arm
+    steps:
+    - name: 🧰 Checkout
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: 📥 Download artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: action
+    - name: 🚧 run action
+      uses: ./
+    - name: 🟩 test CLANGARM64
+      run: msys2 ./test.sh CLANGARM64
+      env:
+        MSYSTEM: CLANGARM64
+
 
   shell:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -187,7 +249,11 @@ jobs:
 
   MSYS2_PATH_TYPE:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     steps:
     - uses: actions/setup-go@v5
     - name: 🧰 Checkout
@@ -207,7 +273,11 @@ jobs:
 
   path-type:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     steps:
     - uses: actions/setup-go@v5
     - name: 🧰 Checkout
@@ -232,7 +302,8 @@ jobs:
       fail-fast: false
       matrix:
         install: [ false, git, 'base-devel git' ]
-    runs-on: windows-latest
+        runs-on: [windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -253,7 +324,11 @@ jobs:
 
   defaultclean:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     defaults:
       run:
         shell: msys2 {0}
@@ -279,7 +354,11 @@ jobs:
 
   defaultdirty:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     defaults:
       run:
         shell: msys2 {0}
@@ -303,7 +382,11 @@ jobs:
 
   errorhandling:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -323,7 +406,11 @@ jobs:
 
   workingdir:
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -368,7 +455,11 @@ jobs:
 
   nocache:
     needs: [cache]
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [windows-latest, windows-11-arm]
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -417,13 +508,14 @@ jobs:
   location:
     name: location | ${{ matrix.location }}
     needs: [cache]
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
+        runs-on: [windows-latest, windows-11-arm]
         location:
-        - D:\
-        - D:\some\arbitrary
+        - \
+        - \some\arbitrary
         - RUNNER_TEMP
     steps:
     - name: 🧰 Checkout
@@ -453,7 +545,7 @@ jobs:
         MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
       run: |
         $Env:MSYS2_ROOT = msys2 -c 'cygpath -a -w /'
-        $Env:MSYS2_ROOT
+        $env:MSYS2_LOCATION = (Resolve-Path "$env:MSYS2_LOCATION").Path
         if ($env:MSYS2_ROOT -ne "$env:MSYS2_LOCATION") {
             Write-Error "Error: MSYS2_ROOT is '$env:MSYS2_ROOT', expected '$env:MSYS2_LOCATION'"
             exit 1
@@ -492,7 +584,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.matrix.outputs.jobs) }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -516,7 +608,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.matrix.outputs.jobs) }}
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
     - name: 🧰 Checkout
       uses: actions/checkout@v4
@@ -537,7 +629,7 @@ jobs:
   install-and-pacboy:
     name: ${{ matrix.icon }} ${{ matrix.sys }} | install-and-pacboy
     needs: matrix
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -566,7 +658,7 @@ jobs:
   pacboy:
     name: ${{ matrix.icon }} ${{ matrix.sys }} | pacboy
     needs: matrix
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/Tool.yml
+++ b/.github/workflows/Tool.yml
@@ -18,14 +18,18 @@ jobs:
     outputs:
       jobs: ${{ steps.matrix.outputs.jobs }}
     steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - id: matrix
-      uses: msys2/setup-msys2/matrix@main
+      uses: ./matrix
       with:
         systems: >-
           mingw32
           mingw64
           ucrt64
           clang64
+          clangarm64
 
   msys2:
     needs: matrix

--- a/examples/cmake.yml
+++ b/examples/cmake.yml
@@ -10,15 +10,16 @@ on:
 jobs:
 
   build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { icon: '⬛', sys: mingw32 }
-          - { icon: '🟦', sys: mingw64 }
-          - { icon: '🟨', sys: ucrt64  }
-          - { icon: '🟧', sys: clang64 }
+          - { icon: '⬛', sys: mingw32, runs-on: 'windows-latest' }
+          - { icon: '🟦', sys: mingw64, runs-on: 'windows-latest' }
+          - { icon: '🟨', sys: ucrt64, runs-on: 'windows-latest' }
+          - { icon: '🟧', sys: clang64, runs-on: 'windows-latest' }
+          - { icon: '🟩', sys: clangarm64, runs-on: 'windows-11-arm' }
     name: 🚧${{ matrix.icon }} ${{ matrix.sys }}
     defaults:
       run:

--- a/matrix/action.yml
+++ b/matrix/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'Space separated list of systems to build and test the tool on.'
     required: false
     type: string
-    default: 'msys mingw32 mingw64 ucrt64 clang64'
+    default: 'msys mingw32 mingw64 ucrt64 clang64 clangarm64'
 outputs:
   jobs:
     description: "List of MSYS2 systems to be used in the matrix of other jobs."
@@ -22,15 +22,19 @@ runs:
       run: |
         import os
         icons = {
-          'msys':    '🟪',
-          'mingw32': '⬛',
-          'mingw64': '🟦',
-          'ucrt64':  '🟨',
-          'clang64': '🟧',
+          'msys':       '🟪',
+          'mingw32':    '⬛',
+          'mingw64':    '🟦',
+          'ucrt64':     '🟨',
+          'clang64':    '🟧',
+          'clangarm64': '🟩',
         }
         jobs = [
-            {'sys': sys.lower(), 'icon': icons[sys.lower()]}
-            for sys in os.environ['INPUT_SYSTEMS'].split(' ')
+            {
+              'sys': sys.lower(),
+              'icon': icons[sys.lower()],
+              'runs-on': 'windows-11-arm' if sys.lower() == 'clangarm64' else 'windows-latest',
+            } for sys in os.environ['INPUT_SYSTEMS'].split(' ')
         ]
         with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as h:
           h.write(f"jobs={jobs!s}\n")


### PR DESCRIPTION
Try to run all the tests on both runner types, except for the
initial build.

The arm runner only has one disk so install so "\" instead of "D:\".
The arm runner also doesn't have an existing MSYS2 install, so skip
the "release: false" test there.